### PR TITLE
Add `package-lock.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# npm's lock file
+package-lock.json


### PR DESCRIPTION
Since you guys are using `yarn.lock`, but I myself prefers using `npm`, we should add `package-lock.json` to `.gitignore` to prevent me accidentally commiting it in.