### PR TITLE
fix(layout): overflow on windows

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -28,7 +28,9 @@ export const PageLayout = ({ children }: { children: JSX.Element }) => {
   // }
 
   return (
-    <div className={clsx('w-full font-display', backgroundColor)}>
+    <div
+      className={clsx('w-full overflow-hidden font-display', backgroundColor)}
+    >
       <Head>
         <title>PROGRAMMING.IN.TH | β</title>
       </Head>


### PR DESCRIPTION
Without `overflow-hidden` on Windows, it will look like this

![image](https://user-images.githubusercontent.com/59821765/185800491-63a6e3c7-5362-4ce7-a182-4c285eda2e3b.png)
![image](https://user-images.githubusercontent.com/59821765/185800677-563bb0ec-2450-4bf8-a83b-b5e3136e2fe9.png)

Adding `overflow-hidden` fixes it

![image](https://user-images.githubusercontent.com/59821765/185800495-77430192-4991-4cc1-b22b-d9d52daef883.png)
